### PR TITLE
Release 3.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [3.2.2] - 2023-04-24
+### Fixed
+- Resolved issue caused by S3 changes to new bucket permissions described in the following release notes https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/. This change is now being rolled out across all regions and causes a failure in the stack deployment if this new setting is not applied.
+- Updated AWS Amplify to the latest in order to resolve dependency and upgrade @sideway/formula module to 3.0.1 to protect against vulnerability described here https://nvd.nist.gov/vuln/detail/CVE-2023-25166.
+- Simplejson python library updated from 3.18.0 to 3.19.1 (Used by in all CMF Lambda functions).
+- Troposphere python library updated from 4.2.0 to 4.3.2 (Used by EC2 Platform functions).
+- Coverage python library updated from 7.0.0 to 7.2.2 (Used only for unit testing).
+- Application Registry - Update to logicalId for the Attribute group to fix CFN error "AttributeGroup name update feature has been deprecated. (Service: ServiceCatalogAppRegistry, Status Code: 400)". This error would occur when a stack update is performed and caused by changes to the AppRegistry service.
+- MGN Rehost - IMDSv2 settings on EC2 launch profile were incorrectly setting the values to enabled and disabled, the only options now are optional and required.
+- EC2 Replatform - resolved issue where Build template incorrectly including all servers with the Replatform r_type without verifying that the application was within the wave selected.
+- Fixed issue when deploying CMF stack with the optional private deployment, and specifying multiple subnet IDs to the PrivateEndpointSubnets parameter. When multiple subnets were provided the VPC endpoint would fail to create as the list was provided as a string and not a list as expected.
 ## [3.2.1] - 2023-01-12
 ### Fixed
 - Updated python requests to 2.28.1 due to security patch required for certifi module which is a dependency. Using the latest requests version 2.28.1 installs the latest patched version of certifi v2022.12.07. For details please refer to https://nvd.nist.gov/vuln/detail/cve-2022-23491.

--- a/deployment/CFN-templates/aws-cloud-migration-factory-solution.template
+++ b/deployment/CFN-templates/aws-cloud-migration-factory-solution.template
@@ -153,6 +153,9 @@ Resources:
     Properties:
       BucketName: !Sub ${Application}-${Environment}-${AWS::AccountId}-access-logs
       AccessControl: LogDeliveryWrite
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: ObjectWriter
       PublicAccessBlockConfiguration:
         BlockPublicAcls: TRUE
         BlockPublicPolicy: TRUE
@@ -707,10 +710,7 @@ Resources:
       ServiceName: !Sub 'com.amazonaws.${AWS::Region}.execute-api'
       VpcId: !Ref EndpointVPCId
       VpcEndpointType: Interface
-      SubnetIds:
-        - !Join
-          - ','
-          - !Ref PrivateEndpointSubnets
+      SubnetIds: !Ref PrivateEndpointSubnets
       PrivateDnsEnabled: true
       SecurityGroupIds:
         - !Ref APIGatewayEndpointSG
@@ -5137,10 +5137,10 @@ Resources:
         !Ref WAFFEStack
       ResourceType: CFN_STACK
 
-  DefaultApplicationAttributes:
+  DefaultApplicationAttributeGroup:
     Type: AWS::ServiceCatalogAppRegistry::AttributeGroup
     Properties:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}'
+      Name: !Sub 'AttrGrp-${AWS::Region}-${AWS::StackName}'
       Description: Attribute group for solution information.
       Attributes:
         { "ApplicationType" : 'AWS-Solutions',
@@ -5153,7 +5153,7 @@ Resources:
     Type: AWS::ServiceCatalogAppRegistry::AttributeGroupAssociation
     Properties:
       Application: !GetAtt AppRegistryApplication.Id
-      AttributeGroup: !GetAtt DefaultApplicationAttributes.Id
+      AttributeGroup: !GetAtt DefaultApplicationAttributeGroup.Id
 
 Outputs:
   MigrationFactoryURL:

--- a/source/backend/lambda_functions/lambda_gfbuild/requirements.txt
+++ b/source/backend/lambda_functions/lambda_gfbuild/requirements.txt
@@ -1,2 +1,2 @@
-troposphere==4.2.0
+troposphere==4.3.2
 # Removed from package as will use Lambda provided boto client last tested version was : boto3==1.17.96

--- a/source/backend/lambda_functions/lambda_schema/requirements.txt
+++ b/source/backend/lambda_functions/lambda_schema/requirements.txt
@@ -1,2 +1,1 @@
-# Removed from package as will use Lambda provided boto client last tested version was : boto3==1.17.96
-simplejson==3.18.0
+simplejson==3.19.1

--- a/source/backend/lambda_layers/lambda_layer_policy/python/requirements.txt
+++ b/source/backend/lambda_layers/lambda_layer_policy/python/requirements.txt
@@ -1,4 +1,4 @@
 # Removed from package as will use Lambda provided boto client last tested version was : boto3==1.17.96
 requests==2.28.1
 python-jose==3.3.0
-simplejson==3.18.0
+simplejson==3.19.1

--- a/source/backend/lambda_layers/lambda_layer_py_pkgs/python/requirements.txt
+++ b/source/backend/lambda_layers/lambda_layer_py_pkgs/python/requirements.txt
@@ -1,5 +1,5 @@
 boto3==1.26.27
 requests==2.28.1
 python-jose==3.3.0
-simplejson==3.18.0
+simplejson==3.19.1
 botocore==1.29.27

--- a/source/backend/lambda_unit_test/requirements.txt
+++ b/source/backend/lambda_unit_test/requirements.txt
@@ -1,6 +1,6 @@
 requests==2.28.1
 python-jose==3.3.0
-simplejson==3.18.0
+simplejson==3.19.1
 boto3==1.24.0
 moto==4.1.0
-coverage==7.0.0
+coverage==7.2.2

--- a/source/frontend/package.json
+++ b/source/frontend/package.json
@@ -6,7 +6,7 @@
     "@awsui/components-react": "^3.0.693",
     "@awsui/global-styles": "^1.0.19",
     "ace-builds": "^1.5.1",
-    "aws-amplify": "^4.3.23",
+    "aws-amplify": "^4.3.46",
     "jquery": "^3.6.0",
     "jquery-csv": "^1.0.21",
     "react": "^17.0.2",

--- a/source/integrations/mgn/lambdas/lambda_mgn_template.py
+++ b/source/integrations/mgn/lambdas/lambda_mgn_template.py
@@ -548,9 +548,9 @@ def create_launch_template(factoryserver, action, new_launch_template, launch_te
 
         if 'instance_metadata_options_http_tokens' in factoryserver:
             if factoryserver['instance_metadata_options_http_tokens']:
-                metadata_options['HttpTokens'] = 'enabled'
+                metadata_options['HttpTokens'] = 'required'
             else:
-                metadata_options['HttpTokens'] = 'disabled'
+                metadata_options['HttpTokens'] = 'optional'
 
         if metadata_options:
             new_launch_template['MetadataOptions'] = metadata_options


### PR DESCRIPTION
### Fixed
- Resolved issue caused by S3 changes to new bucket permissions described in the following release notes https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/. This change is now being rolled out across all regions and causes a failure in the stack deployment if this new setting is not applied.
- Updated AWS Amplify to the latest in order to resolve dependency and upgrade @sideway/formula module to 3.0.1 to protect against vulnerability described here https://nvd.nist.gov/vuln/detail/CVE-2023-25166.
- Simplejson python library updated from 3.18.0 to 3.19.1 (Used by in all CMF Lambda functions).
- Troposphere python library updated from 4.2.0 to 4.3.2 (Used by EC2 Platform functions).
- Coverage python library updated from 7.0.0 to 7.2.2 (Used only for unit testing).
- Application Registry - Update to logicalId for the Attribute group to fix CFN error "AttributeGroup name update feature has been deprecated. (Service: ServiceCatalogAppRegistry, Status Code: 400)". This error would occur when a stack update is performed and caused by changes to the AppRegistry service.
- MGN Rehost - IMDSv2 settings on EC2 launch profile were incorrectly setting the values to enabled and disabled, the only options now are optional and required.
- EC2 Replatform - resolved issue where Build template incorrectly including all servers with the Replatform r_type without verifying that the application was within the wave selected.
- Fixed issue when deploying CMF stack with the optional private deployment, and specifying multiple subnet IDs to the PrivateEndpointSubnets parameter. When multiple subnets were provided the VPC endpoint would fail to create as the list was provided as a string and not a list as expected.