### PR TITLE
Performing Test Launch or Validate Template yields an error of "Submit action failed: 'hostname'"

### DIFF
--- a/source/integrations/mgn/lambdas/lambda_mgn.py
+++ b/source/integrations/mgn/lambdas/lambda_mgn.py
@@ -239,14 +239,17 @@ def verify_target_account_servers(serverlist):
                     isServerExist = False
                     for sourceserver in mgn_sourceservers:
                         # Check if the factory server exist in Application Migration Service
-                        if factoryserver['server_name'].lower().strip() == sourceserver['sourceProperties']['identificationHints']['hostname'].lower().strip():
-                            isServerExist = True
-                        elif factoryserver['server_name'].lower().strip() == sourceserver['sourceProperties']['identificationHints']['fqdn'].lower().strip():
-                            isServerExist = True
-                        elif factoryserver['server_fqdn'].lower().strip() == sourceserver['sourceProperties']['identificationHints']['hostname'].lower().strip():
-                            isServerExist = True
-                        elif factoryserver['server_fqdn'].lower().strip() == sourceserver['sourceProperties']['identificationHints']['fqdn'].lower().strip():
-                            isServerExist = True
+
+                        # Confirm the hostname and fqdn keys exist before checking for them
+                        if ('hostname' and 'fqdn') in sourceserver['sourceProperties']['identificationHints']:
+                            if factoryserver['server_name'].lower().strip() == sourceserver['sourceProperties']['identificationHints']['hostname'].lower().strip():
+                                isServerExist = True
+                            elif factoryserver['server_name'].lower().strip() == sourceserver['sourceProperties']['identificationHints']['fqdn'].lower().strip():
+                                isServerExist = True
+                            elif factoryserver['server_fqdn'].lower().strip() == sourceserver['sourceProperties']['identificationHints']['hostname'].lower().strip():
+                                isServerExist = True
+                            elif factoryserver['server_fqdn'].lower().strip() == sourceserver['sourceProperties']['identificationHints']['fqdn'].lower().strip():
+                                isServerExist = True
                         else:
                             continue
                         # Get EC2 launch template Id for the source server in Application Migration Service


### PR DESCRIPTION
Fix:
This issue has been resolved in our environment with a change to the lambda_mgn.py. This PR code checks for Hostname and FQDN key in the dictionary before doing a comparison of values between CMF and MGN.

Issue:
Two servers sitting in Archive in our MGN were previously from performing an Import into MGN. However, no agents were ever installed, so Hostname and FQDN values did not exist on the servers in MGN. When trying to do a Validate Launch Template or Launch Test Instances from CMF into MGN would cause an error response of "Submit action failed: 'hostname'".