### PR TITLE
support single type EC2 Dedicated Hosts from MGN integration

### DIFF
--- a/source/integrations/mgn/lambdas/lambda_mgn_template.py
+++ b/source/integrations/mgn/lambdas/lambda_mgn_template.py
@@ -416,7 +416,12 @@ def verify_dedicated_host(ec2_client, dedicated_host_id, requested_instance_type
         if 'Hosts' in dedicated_hosts:
             if len(dedicated_hosts['Hosts']) == 1:
                 # Check that the instance type is matching this dedicated host.
-                Instance_family = dedicated_hosts['Hosts'][0]['HostProperties']['InstanceFamily']
+                if 'InstanceFamily' in dedicated_hosts['Hosts'][0]['HostProperties']:
+                    Instance_family = dedicated_hosts['Hosts'][0]['HostProperties']['InstanceFamily']
+                else:
+                    # Some dedicated hosts only have single instance type support, so InstanceFamily will not be defined.
+                    # Determine the family from the InstanceType value
+                    Instance_family = dedicated_hosts['Hosts'][0]['HostProperties']['InstanceType'].split(".")[0]
                 if requested_instance_type.split(".")[0] != Instance_family:
                     return 'ERROR: Host Supported Instance Family does not match required (Host=' + Instance_family + ', Requested=' + \
                            requested_instance_type.split(".")[0] + ')'


### PR DESCRIPTION
*Issue*
When using certain EC2 Dedicated Hosts (e.g. _r5d.large_), they are restricted to a single Instance Type. The side effect from this is that the ec2:DescribeHosts response for these hosts will not include `InstanceFamily` in the HostProperties.

Currently, the MGN lambda function assumes it will be able to resolve the InstanceFamily from the response, and will unfortunately fail when it is not present.

>ERROR: Host Supported Instance Family does not match required

*Description of changes:*
This change includes logic to identify whether the ec2:DescribeHosts response contains the `InstanceFamily`, and if not, will instead use the `InstanceType` value to glean the instance family.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
