### PR TITLE
BUILD: added urllib3 library into requirements to force version to 2.…

### DIFF
--- a/source/backend/lambda_layers/lambda_layer_policy/python/requirements.txt
+++ b/source/backend/lambda_layers/lambda_layer_policy/python/requirements.txt
@@ -1,4 +1,5 @@
 # Removed from package as will use Lambda provided boto client last tested version was : boto3==1.17.96
+urllib3<2.1.0
 requests==2.31.0
 PyJWT==2.8.0
 PyJWT[crypto]==2.8.0

--- a/source/backend/lambda_layers/lambda_layer_py_pkgs/python/requirements.txt
+++ b/source/backend/lambda_layers/lambda_layer_py_pkgs/python/requirements.txt
@@ -1,3 +1,4 @@
+urllib3<2.1.0
 boto3==1.34.28
 requests==2.31.0
 simplejson==3.19.2

--- a/source/backend/lambda_unit_test/requirements.txt
+++ b/source/backend/lambda_unit_test/requirements.txt
@@ -1,3 +1,4 @@
+urllib3<2.1.0
 requests==2.31.0
 python-jose==3.3.0
 python-jose[cryptography]==3.3.0

--- a/source/integrations/integration_unit_tests/requirements.txt
+++ b/source/integrations/integration_unit_tests/requirements.txt
@@ -1,3 +1,4 @@
+urllib3<2.1.0
 boto3==1.33.11
 botocore==1.33.11
 moto==4.2.0


### PR DESCRIPTION
*Description of changes:*

added urllib3 library into requirements to force version to 2.1.0, as botocore is not compatible with the latest release 2.2.0 and causes runtime errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
