### PR TITLE
Added permissions required for Post-Launch actions to run

### DIFF
--- a/deployment/CFN-templates/aws-cloud-migration-factory-solution-target-account.template
+++ b/deployment/CFN-templates/aws-cloud-migration-factory-solution-target-account.template
@@ -86,7 +86,6 @@ Resources:
                   - 'ssm:GetAutomationExecution'
                   - 'ssm:StartAutomationExecution'
                   - 'ssm:DescribeDocument'
-                  - 'ssm:GetDocument'
                 Resource:
                   - 'arn:aws:ssm:*:*:document/*'
                   - 'arn:aws:ssm:*:*:automation-definition/*:*'
@@ -94,8 +93,6 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:DescribeInstanceInformation'
-                  - 'ssm:SendCommand'
-                  - 'ssm:StartSession'
                 Resource: '*'
         - PolicyName: MGNPostLaunchActions
           PolicyDocument:
@@ -111,7 +108,10 @@ Resources:
                   - 'ssm:DeleteParameters'
                   - 'ssm:GetParameter'
                   - 'ssm:GetParameters'
+                  - 'ssm:SendCommand'
                   - 'ssm:GetDocument'
+                  - 'ssm:StartSession'
+                  - 'ssm:ListCommandInvocations'
                 Resource: '*'
         -
           PolicyName: LambdaRolePolicy


### PR DESCRIPTION
*Issue #, if available:*

Solves issue #37 

*Description of changes:*

Added permissions required to run Post-Launch SSM Document based actions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
